### PR TITLE
pyprind 2.11.3 :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+upload_channels:
+  - sfe1ed40
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "PyPrind" %}
-{% set version = "2.11.2" %}
-{% set sha256 = "c46cab453b805852853dfe29fd933aa88a2a516153909c695b098e9161a9e675" %}
+{% set version = "2.11.3" %}
+{% set sha256 = "e37dcab6e1a9c8e0a7f0fce65fde7a79e2deda1c75aa015910a49e2137b54cbf" %}
 
 package:
   name: {{ name|lower }}
@@ -13,7 +13,7 @@ source:
 
 build:
   number: 1005
-  script: python setup.py install --single-version-externally-managed --record record.txt
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   build:
@@ -21,7 +21,9 @@ requirements:
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
   host:
     - python
+    - pip
     - setuptools
+    - wheel
   run:
     - python
     - psutil >=3.2.0
@@ -29,6 +31,10 @@ requirements:
 test:
   imports:
     - pyprind
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/rasbt/pyprind
@@ -40,7 +46,7 @@ about:
     The PyPrind (Python Progress Indicator) module provides a progress bar
     and a percentage indicator object that let you track the progress of a
     loop structure or other iterative computation.
-  doc_url: http://pythonhosted.org/PyPrind/
+  doc_url: https://pythonhosted.org/PyPrind/
   dev_url: https://github.com/rasbt/pyprind
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
   run:
     - python
   run_constrained:
-    - psutil
+    - psutil >=3.2.0
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,6 @@
 {% set name = "PyPrind" %}
+# XXX Technically, there is no git tag for 2.11.3 but the sole commit
+# since 2.11.2's CHANGELOG does indicate it is meant to be 2.11.3
 {% set version = "2.11.3" %}
 {% set sha256 = "e37dcab6e1a9c8e0a7f0fce65fde7a79e2deda1c75aa015910a49e2137b54cbf" %}
 
@@ -29,12 +31,16 @@ requirements:
     - psutil >=3.2.0
 
 test:
+  source_files:
+    - tests
   imports:
     - pyprind
   requires:
     - pip
+    - pytest
   commands:
     - pip check
+    - pytest -v tests
 
 about:
   home: https://github.com/rasbt/pyprind

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,7 @@
 {% set name = "PyPrind" %}
-# XXX Technically, there is no git tag for 2.11.3 but the sole commit
-# since 2.11.2's CHANGELOG does indicate it is meant to be 2.11.3
+# XXX Technically, there is no git tag for 2.11.3 but in the sole
+# commit since 2.11.2, 881fa94e, the CHANGELOG does indicate it is
+# meant to be 2.11.3
 {% set version = "2.11.3" %}
 {% set sha256 = "e37dcab6e1a9c8e0a7f0fce65fde7a79e2deda1c75aa015910a49e2137b54cbf" %}
 
@@ -9,18 +10,14 @@ package:
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
-  number: 1005
+  number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
-  build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
   host:
     - python
     - pip
@@ -28,7 +25,8 @@ requirements:
     - wheel
   run:
     - python
-    - psutil >=3.2.0
+  run_constrained:
+    - psutil
 
 test:
   source_files:
@@ -38,6 +36,7 @@ test:
   requires:
     - pip
     - pytest
+    - psutil
   commands:
     - pip check
     - pytest -v tests


### PR DESCRIPTION
pyprind 2.11.3 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-5065]
- dev_url:        https://github.com/rasbt/pyprind
- conda_forge:    https://github.com/conda-forge/PyPrind-feedstock/blob/main/recipe/meta.yaml
- pypi:           n/a
- pypi inspector: https://inspector.pypi.io/project/PyPrind/2.11.3

### Explanation of changes:

- basic build
- upstream tests


[PKG-5065]: https://anaconda.atlassian.net/browse/PKG-5065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ